### PR TITLE
Rename twitter_id to twitter_username

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,9 +34,9 @@ task :generate_team do
   
   team = YAML.load_file('team.yaml')
   team.each do |member| 
-    p "Getting #{ member[:twitter_id] }"
+    p "Getting #{ member[:twitter_username] }"
     
-    twitter_user = client.user member[:twitter_id]
+    twitter_user = client.user member[:twitter_username]
     
     member[:twitter_profile_url] = twitter_user.profile_image_uri_https.to_s
     member[:twitter_banner_url] = twitter_user.profile_banner_uri.to_s

--- a/data/dev_team.yaml
+++ b/data/dev_team.yaml
@@ -1,56 +1,56 @@
 ---
 - name: Eloy Duran
-  twitter_id: alloy
+  twitter_username: alloy
   cocoapods_bio: Creator, maintainer & instigator.
   :twitter_profile_url: https://abs.twimg.com/sticky/default_profile_images/default_profile_1_normal.png
   :twitter_banner_url: ''
 - name: Fabio Pelosin
-  twitter_id: fabiopelosin
+  twitter_username: fabiopelosin
   cocoapods_bio: Programmer at Large.
   :twitter_profile_url: https://abs.twimg.com/sticky/default_profile_images/default_profile_1_normal.png
   :twitter_banner_url: ''
 - name: orta
-  twitter_id: orta
+  twitter_username: orta
   cocoapods_bio: Design Dictator.
   :twitter_profile_url: https://abs.twimg.com/sticky/default_profile_images/default_profile_1_normal.png
   :twitter_banner_url: ''
 - name: 'Keith Smiley '
-  twitter_id: smileykeith
+  twitter_username: smileykeith
   cocoapods_bio: Master of the Specs.
   :twitter_profile_url: https://abs.twimg.com/sticky/default_profile_images/default_profile_1_normal.png
   :twitter_banner_url: ''
 - name: 'Florian Hanke '
-  twitter_id: hanke
+  twitter_username: hanke
   cocoapods_bio: Still Searching...
   :twitter_profile_url: https://abs.twimg.com/sticky/default_profile_images/default_profile_1_normal.png
   :twitter_banner_url: ''
 - name: Andy Myers
-  twitter_id: andyrmyers
+  twitter_username: andyrmyers
   cocoapods_bio: Really doing the design.
   :twitter_profile_url: https://abs.twimg.com/sticky/default_profile_images/default_profile_1_normal.png
   :twitter_banner_url: ''
 - name: Marin Usalj
-  twitter_id: mneorr
+  twitter_username: mneorr
   cocoapods_bio: .
   :twitter_profile_url: https://abs.twimg.com/sticky/default_profile_images/default_profile_1_normal.png
   :twitter_banner_url: ''
 - name: Michele Titolo
-  twitter_id: micheletitolo
+  twitter_username: micheletitolo
   cocoapods_bio: .
   :twitter_profile_url: https://abs.twimg.com/sticky/default_profile_images/default_profile_1_normal.png
   :twitter_banner_url: ''
 - name: Kyle Fuller
-  twitter_id: kylefuller
+  twitter_username: kylefuller
   cocoapods_bio: .
   :twitter_profile_url: https://abs.twimg.com/sticky/default_profile_images/default_profile_1_normal.png
   :twitter_banner_url: ''
 - name: Joshua Kalpin
-  twitter_id: joshkaplin
+  twitter_username: joshkaplin
   cocoapods_bio: .
   :twitter_profile_url: https://abs.twimg.com/sticky/default_profile_images/default_profile_1_normal.png
   :twitter_banner_url: ''
 - name: Swizzlr
-  twitter_id: swizzlr
+  twitter_username: swizzlr
   cocoapods_bio: .
   :twitter_profile_url: https://abs.twimg.com/sticky/default_profile_images/default_profile_1_normal.png
   :twitter_banner_url: ''

--- a/team.yaml
+++ b/team.yaml
@@ -1,44 +1,44 @@
 ---
 - name: 'Eloy Durán'
-  twitter_id: 'alloy'
+  twitter_username: 'alloy'
   cocoapods_bio: "Creator, maintainer, and instigator."
 
 - name: 'Fabio Pelosin'
-  twitter_id: 'fabiopelosin'
+  twitter_username: 'fabiopelosin'
   cocoapods_bio: "Programmer at Large."
 
 - name: 'orta'
-  twitter_id: 'orta'
+  twitter_username: 'orta'
   cocoapods_bio: "Design Dictator."
 
 - name: 'Keith Smiley '
-  twitter_id: 'smileykeith'
+  twitter_username: 'smileykeith'
   cocoapods_bio: "Master of the Specs."
 
 - name: 'Florian Hanke '
-  twitter_id: 'hanke'
+  twitter_username: 'hanke'
   cocoapods_bio: "Still Searching..."
 
 - name: 'Andy Myers'
-  twitter_id: 'andyrmyers'
+  twitter_username: 'andyrmyers'
   cocoapods_bio: "Really doing the design."
 
 - name: 'Marin Usalj'
-  twitter_id: 'mneorr'
+  twitter_username: 'mneorr'
   cocoapods_bio: "."
 
 - name: 'Michele Titolo'
-  twitter_id: 'micheletitolo'
+  twitter_username: 'micheletitolo'
   cocoapods_bio: "."
 
 - name: 'Kyle Fuller'
-  twitter_id: 'kylefuller'
+  twitter_username: 'kylefuller'
   cocoapods_bio: "."
 
 - name: 'Joshua Kalpin'
-  twitter_id: 'joshkaplin'
+  twitter_username: 'joshkaplin'
   cocoapods_bio: "."
 
 - name: 'Swizzlr'
-  twitter_id: 'swizzlr'
+  twitter_username: 'swizzlr'
   cocoapods_bio: "."


### PR DESCRIPTION
"user_id" parameter in the Twitter REST API is always an integer representing the actual user ID. They use "screen_name" when refering to the actual username.

I think it's a bad idea to use the term "id" when twitter use this term for an actual ID and not the username. Perhaps this should be changed to `twitter_screen_name` instead of `twitter_username`.
