### PR TITLE
Update Marin's twitter username

### DIFF
--- a/data/dev_team.yaml
+++ b/data/dev_team.yaml
@@ -30,7 +30,7 @@
   :twitter_profile_url: https://pbs.twimg.com/profile_images/415145378627862528/TDAPjav-.jpeg
   :twitter_banner_url: http://pbs.twimg.com/profile_banners/15503664/1387813885/web
 - name: Marin Usalj
-  twitter_username: mneorr
+  twitter_username: _supermarin
   cocoapods_bio: Breaking software.
   :twitter_profile_url: https://pbs.twimg.com/profile_images/378800000119552231/ff60c2d1e7ee0dfd8f3c7b7c885ed528.png
   :twitter_banner_url: http://pbs.twimg.com/profile_banners/259575244/1387055988/web


### PR DESCRIPTION
Original `mneorr` account has been renamed to `_supermarin` at February, 24:
https://twitter.com/mneorr/status/437807180696129536
