### PR TITLE
Add platform version to Getting Started example

### DIFF
--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -62,7 +62,7 @@ title: CocoaPods Guides
               in your Xcode project directory:
               <pre class="highlight">
               $ edit Podfile
-              platform :ios
+              platform :ios, '7.0'
               pod 'JSONKit',       '~> 1.4'
               pod 'Reachability',  '~> 3.0'
               </pre>


### PR DESCRIPTION
The default deployment target is currently 4.3 (via [docs](http://guides.cocoapods.org/syntax/podfile.html#platform)), but (my gut is) this default doesn't work with the majority of popular or recent pods. If you start a Podfile with something like AFNetworking and no specified target, it throws this unfriendly error:

```
[!] The platform of the target `Pods` (iOS 4.3) is not compatible with `AFNetworking (2.2.1)` which has a minimum requirement of iOS 6.0 - OS X 10.8.
```

The current "Getting Started" doesn't hint why CocoaPods picked 4.3 or where you can specify an OS version, and I think appending the '7.0' (or some version number) would help clarify and prevent that error when folks copypaste the "Getting Started" example verbatim.

If that's not kosher, an alternative could be changing the above error message to include a suggestion like "Try editing your Podfile's `platform` to `platform :ios, '6.0'`" etc.
