### PR TITLE
Fix getting started instructions

### DIFF
--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -66,6 +66,10 @@ title: CocoaPods Guides
               pod 'Reachability',  '~> 3.0'
               </pre>
               
+              _Tip: CocoaPods provides the `pod init` command to create a template
+              Podfile that may be a good starting point (you still need to edit it then,
+              to list the pods/dependencies you are interested in)_
+              
               Now you can install the dependencies in your project:
             
               <pre class="highlight">


### PR DESCRIPTION
The `edit` command is not a built-in one, so users may not have it.

We should just instruct to "open the Podfile with your favorite text editor" instead.

(Or maybe we can replace `edit Podfile` with `open -t Podfile`?)
