### PR TITLE
search.config.js: Update spec URL

### DIFF
--- a/source/javascripts/search.config.js
+++ b/source/javascripts/search.config.js
@@ -161,7 +161,7 @@ $(window).ready(function() {
     
     entry.docs_link = entry.documentation_url || 'http://cocoadocs.org/docsets/' + entry.id + '/' + entry.version;
     entry.site_link = entry.link || extractRepoFromSource(entry) 
-    entry.spec_link = 'https://github.com/CocoaPods/Specs/tree/master/' + entry.id + '/' + entry.version + '/' + entry.id + '.podspec'
+    entry.spec_link = 'https://github.com/CocoaPods/Specs/tree/master/Specs/' + entry.id + '/' + entry.version + '/' + entry.id + '.podspec.json'
     entry.minor_version = entry.version.split('.').slice(0, 2).join(".")
     
     // render with ICanHaz, see _search-templates


### PR DESCRIPTION
In what can only be described as an act of pure benevolence,
@alloy moved all .podspec files in CocoaPods/Specs into a subdirectory,
thereby saving thousands from unnecessarily long load times.

https://github.com/CocoaPods/Specs/commit/b947340d648f51d66a6df1cbd1b5f7d8cf5a6de0

Surely, the need to change each spec's URL is a trivial price to pay in
order to enjoy such a change.
