### PR TITLE
Add cocoapods-archive to list of plugins

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -99,6 +99,13 @@
       "author":"Denys Telezhkin",
       "url":"https://github.com/DenHeadless/cocoapods-sorted-search",
       "description":"Adds a sort subcommand for pod search to sort search results by amount of stars, forks, or github activity."
+    },
+    {
+      "gem":"cocoapods-archive",
+      "name":"Archive",
+      "author":"Mickey Reiss",
+      "url":"https://github.com/braintreeps/cocoapods-archive",
+      "description":"A CocoaPods plugin that enables you to archive your Pod as a static library"
     }
   ]
 }


### PR DESCRIPTION
`CocoaPods Archive` is a new plugin for Pod developers that generates static libraries from a CococaPods. 

I'll give a disclaimer in case we don't want to list it on the website yet. This plugin is brand new and does not cover all use cases. That being said, I'm finding it useful and it is now a part of my deployment process to help out the developers out there who aren't yet on CocoaPods.
