### PR TITLE
Use full version number for clipboard link when prerelease flag exists

### DIFF
--- a/source/_search-templates.html.slim
+++ b/source/_search-templates.html.slim
@@ -1,7 +1,7 @@
 / see http://icanhazjs.com for docs
 
 ruby:
-  popover_html = "<h4 class='has-flash'>Copy to clipboard</h4><h4 class='no-flash'>For your <a href='http://guides.cocoapods.org/using/the-podfile.html'>Podfile</a></h4><pre><code>pod '{{ id }}', '~> {{ minor_version }}'</code></pre><input class='no-flash' value=\"pod '{{ id }}', '~> {{ minor_version }}'\" type=text>"
+  popover_html = "<h4 class='has-flash'>Copy to clipboard</h4><h4 class='no-flash'>For your <a href='http://guides.cocoapods.org/using/the-podfile.html'>Podfile</a></h4><pre><code>pod '{{ id }}', '{{ clipboard_version }}'</code></pre><input class='no-flash' value=\"pod '{{ id }}', '{{ clipboard_version }}'\" type=text>"
 
 script id="search_result" type="text/html"
 
@@ -16,7 +16,7 @@ script id="search_result" type="text/html"
         a href="{{ link }}" {{ id }}
         span.version {{ version }}
         | {{/deprecated}}
-        img.copy src="./images/copy-to-clipboard.png" data-clipboard-text="pod '{{ id }}', '~> {{ minor_version }}'" data-toggle="popover" data-placement="top" data-container="body" data-html="true" data-content=popover_html
+        img.copy src="./images/copy-to-clipboard.png" data-clipboard-text="pod '{{ id }}', '{{ clipboard_version }}'" data-toggle="popover" data-placement="top" data-container="body" data-html="true" data-content=popover_html
 
         | {{#platform}}
         span.os {{ platform }}

--- a/source/javascripts/search.config.js
+++ b/source/javascripts/search.config.js
@@ -164,7 +164,17 @@ $(window).ready(function() {
     entry.docs_link = entry.documentation_url || 'http://cocoadocs.org/docsets/' + entry.id + '/' + entry.version;
     entry.site_link = entry.link || extractRepoFromSource(entry)
     entry.spec_link = 'https://github.com/CocoaPods/Specs/tree/master/Specs/' + entry.id + '/' + entry.version + '/' + entry.id + '.podspec.json'
-    entry.minor_version = entry.version.split('.').slice(0, 2).join(".")
+
+    // If the version string has any non-numeric characters (pre-release or build metadata flags),
+    // the clipboard copy prompt should use the raw version number.
+    // (https://github.com/CocoaPods/cocoapods.org/issues/79)
+    if (entry.version.match(/[^.0-9]/)) {
+      entry.clipboard_version = entry.version;
+    } else {
+      var minor_version = entry.version.split('.').slice(0, 2).join(".")
+      entry.clipboard_version = "~> " + minor_version;
+    }
+
     if (entry.deprecated_in_favor_of) {
       entry.deprecated_in_favor_of_link = "http://cocoapods.org?q=" + entry.deprecated_in_favor_of;
     } else {


### PR DESCRIPTION
Should be a pretty straight-forward fix for #79.

Since this string is used in three different places on the page, it made sense to me to put the conditional logic to build up the string with or without the `~>` in the JS side rather than within the template.

(Am I correct in assuming there aren't any tests in this repo?)
