### PR TITLE
Fix #65

### DIFF
--- a/middleman/source/about.html.slim
+++ b/middleman/source/about.html.slim
@@ -173,7 +173,7 @@ section.title.container.about-section
         - if data.team.index(dev) % 3 == 0
           .clearfix.hidden-xs
 
-        .col-lg-4.col-sm-4.col-xs-6.dev-team
+        .col-lg-4.col-sm-4.col-xs-12.dev-team
           .card
             .background style="background-image:url(#{dev.twitter_banner_url})"
 


### PR DESCRIPTION
On extra small (<768px) devices volunteer driven Twitter profiles are displayed one per line.