### PR TITLE
Feature/quality estimate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem "twitter"
 gem 'link_header'
 gem 'sprockets'
 
+gem 'httparty'
+
 group :development, :production do
   gem 'foreman'
   gem 'thin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,9 @@ GEM
     http (0.6.3)
       http_parser.rb (~> 0.6.0)
     http_parser.rb (0.6.0)
+    httparty (0.13.3)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
     i18n (0.7.0)
     json (1.8.2)
     link_header (0.0.8)
@@ -66,6 +69,7 @@ GEM
     method_source (0.8.2)
     minitest (5.5.1)
     multi_json (1.10.1)
+    multi_xml (0.5.5)
     multipart-post (2.0.0)
     nap (0.8.0)
     naught (1.0.0)
@@ -134,6 +138,7 @@ DEPENDENCIES
   flounder
   foreman
   github-markup
+  httparty
   link_header
   nap
   pry

--- a/app.rb
+++ b/app.rb
@@ -5,6 +5,7 @@ require 'net/http'
 require 'cocoapods-core'
 require 'yaml'
 require_relative 'spec_extensions'
+require_relative 'lib/pod_quality_estimate'
 require 'sprockets'
 require 'set'
 require 'digest/md5'
@@ -91,6 +92,12 @@ class App < Sinatra::Base
     @gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar}.png?d=retro&r=PG&s=240"
 
     slim :owner
+  end
+
+  get '/pods/:name/quality' do
+    @name = params[:name]
+    @quality = PodQualityEstimate.load_quality_estimate(@name)
+    slim :pod_quality
   end
 
   def pod_page_for_result result

--- a/assets/stylesheets/pod.scss.erb
+++ b/assets/stylesheets/pod.scss.erb
@@ -9,6 +9,57 @@ $background-color: #F2F2F2;
 $alt-link-color: #B7233F;
 $warning-color: #B80E3D;
 
+#headline {
+  height:320px;
+  padding:0;
+}
+
+#headline > div {
+  position: relative;
+  height:100%;
+}
+
+#headline > div > h1 {
+  bottom: 20px;
+  left: 0px;
+  font-size: 72px;
+  font-weight:normal;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  height: 74px;
+  line-height: 63px;
+  color: #ED0015;
+  position: absolute;
+  padding: 0;
+  margin-bottom: 0;
+  width:100%;
+}
+
+h1 span {
+  color: whitesmoke;
+}
+
+@media (max-width:768px){
+  #headline {
+    height:120px;
+  }
+  #headline > div > h1 {
+    font-size:32px;
+    text-align:center;
+  }
+}
+
+.quality-content {
+  padding-bottom: 20px;
+  padding-top: 15px;
+  background: #FFF;
+
+  .score {
+    text-align: center;
+    background-color: #f5f5f5;
+  }
+}
 
 .readme-content {
   border-right: 2px solid black;
@@ -61,6 +112,7 @@ $warning-color: #B80E3D;
   }
 
   h1 {
+    border-left: 4px $highlight-color solid;
     padding-left: 20px;
     margin-left:-30px;
     font-size: 48px;

--- a/lib/pod_quality_estimate.rb
+++ b/lib/pod_quality_estimate.rb
@@ -1,0 +1,56 @@
+require 'httparty'
+
+CalculationStep = Struct.new(:description, :title, :score, :type) do
+  def inspect
+    "Description: #{description}, Score: #{score}, Type: #{type}"
+  end
+
+  def css_class
+    case type
+    when :base_score
+      'base-score'
+    when :modifier
+      if score > 0
+        'positive-score'
+      else
+        'negative-score'
+      end
+    end
+  end
+
+  def score_text
+    return "#{score}" if score < 0 || type == :base_score
+
+    "+ #{score}"
+  end
+end
+
+class PodQualityEstimate
+  include HTTParty
+  base_uri 'https://cocoadocs-api-cocoapods-org.herokuapp.com'
+  format :json
+  attr_reader :calculation_steps
+
+  def self.load_quality_estimate(pod_name)
+    response = self.get("/pods/#{pod_name}/stats", headers: { 'Content-Type' => 'application/json; charset=UTF-8' })
+
+    steps = []
+    base = response.parsed_response['base']
+    steps << CalculationStep.new(base['description'], nil, base['score'], :base_score)
+
+    steps << response.parsed_response['metrics'].reject { |metric| !metric['applies_for_pod'] }.map do |metric|
+      CalculationStep.new(metric['description'], metric['title'], metric['modifier'], :modifier)
+    end
+
+    self.new(pod_name, steps.flatten)
+  end
+
+  def initialize(pod_name, calculation_steps)
+    @pod_name = pod_name
+    @calculation_steps = calculation_steps
+  end
+
+  def total_score
+    @calculation_steps.map(&:score).reduce(:+)
+  end
+end

--- a/lib/pod_quality_estimate.rb
+++ b/lib/pod_quality_estimate.rb
@@ -19,9 +19,9 @@ CalculationStep = Struct.new(:description, :title, :score, :type) do
   end
 
   def score_text
-    return "#{score}" if score < 0 || type == :base_score
+    return "#{score}".gsub(/\s+/, "") if score < 0 || type == :base_score
 
-    "+ #{score}"
+    "+#{score}"
   end
 end
 

--- a/views/pod_page.slim
+++ b/views/pod_page.slim
@@ -1,56 +1,14 @@
-css:
-  #headline {
-    height:320px;
-    padding:0;
-  }
-  
-  #headline > div {
-    position: relative;
-    height:100%;
-  }
-    
-  #headline > div > h1 {
-    bottom: 20px;
-    left: 0px;
-    font-size: 72px;
-    font-weight:normal;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    height: 74px;
-    line-height: 63px;
-    color: #ED0015;
-    position: absolute;
-    padding: 0;
-    margin-bottom: 0; 
-    width:100%;
-  }
-  
-  h1 span {
-    color: whitesmoke;
-  }
-  
-  @media (max-width:768px){
-    #headline {
-      height:120px;
-    }
-    #headline > div > h1 {
-      font-size:32px;
-      text-align:center;
-    }
-  }
-
 section.container
-  article.row#headline  
+  article.row#headline
     .col-lg-12.col-sm-12.col-xs-12
       h1 == @pod.name + " <span>" + @pod.version.to_s + "</span>"
-      
+
 
 #content-wrapper
   section.container#pod-page
     article.row
       == @content
-      
+
 javascript:
   $copy_to_clipboard = $('ol.results img.copy')
 

--- a/views/pod_quality.slim
+++ b/views/pod_quality.slim
@@ -11,10 +11,10 @@ css:
     color: #72CC1D;
   }
 
-  div.score h2 {
-    margin: 0;
-    height: 100%;
-    line-height: 100%;
+  div.score h1 {
+    font-size: 45px;
+    line-height: 140%;
+    height: 40%;
   }
 
   div.score {
@@ -36,6 +36,10 @@ css:
     right: 0;
   }
 
+  div.details {
+    margin-left: 35px;
+  }
+
 section.container
   article.row#headline
     .col-lg-12.col-sm-12.col-xs-12
@@ -49,8 +53,8 @@ section.container
           .row
             .col-sm-1.score.col-sm-offset-1 class=(step.css_class)
               .content
-                h2 == step.score_text
-            .col-sm-9.col-sm-offset-1
+                h1 == step.score_text
+            .col-sm-9.details
               - if step.title
                 h3.estimate-step-title == step.title
               - else
@@ -58,5 +62,6 @@ section.container
               p == step.description
         .row
           .col-sm-1.score.col-sm-offset-1
-            h2 == @quality.total_score
+            .content
+              h1 == @quality.total_score
 

--- a/views/pod_quality.slim
+++ b/views/pod_quality.slim
@@ -40,6 +40,24 @@ css:
     margin-left: 35px;
   }
 
+  div.divider {
+    margin-top: -25px;
+    margin-bottom: -30px;
+  }
+
+  div.single {
+    width: 4px;
+    background-color: #f5f5f5;
+    align-content: center;
+    position: absolute;
+    top: 0px;
+    bottom: 5px;
+  }
+
+  div.details > p {
+    margin-top: -10px;
+  }
+
 section.container
   article.row#headline
     .col-lg-12.col-sm-12.col-xs-12
@@ -50,6 +68,11 @@ section.container
     article.row
       .quality-content.col-sm-12
         - @quality.calculation_steps.each do |step|
+          - if step.title
+            .row.divider
+              .col-sm-1.col-sm-offset-1
+                .row
+                  .col-sm-offset-6.single
           .row
             .col-sm-1.score.col-sm-offset-1 class=(step.css_class)
               .content
@@ -60,8 +83,14 @@ section.container
               - else
                 h3.estimate-step-title == "<br/>"
               p == step.description
+        .row.divider
+              .col-sm-1.col-sm-offset-1
+                .row
+                  .col-sm-offset-5.single
+                  .col-sm-offset-7.single
         .row
           .col-sm-1.score.col-sm-offset-1
             .content
               h1 == @quality.total_score
+        
 

--- a/views/pod_quality.slim
+++ b/views/pod_quality.slim
@@ -1,0 +1,60 @@
+css:
+  h3.estimate-step-title {
+    margin-top: 0;
+    color: #fb0006;
+  }
+  div.base-score, div.negative-score {
+    color: #fb0006;
+  }
+
+  div.positive-score {
+    color: #72CC1D;
+  }
+
+  div.score h2 {
+    margin: 0;
+    height: 100%;
+    line-height: 100%;
+  }
+
+  div.score {
+    position: relative;
+    padding: 0;
+  }
+
+  div.score:before {
+    content: "";
+    display: block;
+    padding-top: 100%;  /* initial ratio of 1:1*/
+  }
+
+  div.score > .content {
+    position:  absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+  }
+
+section.container
+  article.row#headline
+    .col-lg-12.col-sm-12.col-xs-12
+      h1 == @name
+
+#content-wrapper
+  section.container
+    article.row
+      .quality-content.col-sm-12
+        - @quality.calculation_steps.each do |step|
+          .row
+            .col-sm-1.score.col-sm-offset-1 class=(step.css_class)
+              .content
+                h2 == step.score_text
+            .col-sm-9.col-sm-offset-1
+              - if step.title
+                h3.estimate-step-title == step.title
+              p == step.description
+        .row
+          .col-sm-1.score.col-sm-offset-1
+            h2 == @quality.total_score
+

--- a/views/pod_quality.slim
+++ b/views/pod_quality.slim
@@ -53,6 +53,8 @@ section.container
             .col-sm-9.col-sm-offset-1
               - if step.title
                 h3.estimate-step-title == step.title
+              - else
+                h3.estimate-step-title == "<br/>"
               p == step.description
         .row
           .col-sm-1.score.col-sm-offset-1


### PR DESCRIPTION
# Fix #134 
- Fixing «total» explanation positioning
- Removed «empty» whitespace between sign and number (e.g.: `+ 1` vs `+1`)
- Added total to `content` div to contain it from extending
- Added dividers between «sections»

Below are some screenshots of how it currently looks for `AFNetworking` & `ORStackView`
![quality - afnetworking](https://cloud.githubusercontent.com/assets/2642850/7719496/860a0106-fe7e-11e4-9cc4-e1d7e69fa4be.png)
![quality - orstackview](https://cloud.githubusercontent.com/assets/2642850/7719497/860a47ec-fe7e-11e4-9940-83aab17336a0.png)

---
![MRW my GF is taking off all her clothes before bed, but then puts on pyjamas.](http://i.imgur.com/8mzkNIB.gif)