### PR TITLE
Added support for mobile sites (quality view).

### DIFF
--- a/views/pod_quality.slim
+++ b/views/pod_quality.slim
@@ -25,7 +25,15 @@ css:
   div.score:before {
     content: "";
     display: block;
-    padding-top: 100%;  /* initial ratio of 1:1*/
+    padding-top: 100%;  /* initial ratio of 1:1 */
+  }
+
+  @media (max-width:765px){
+    div.totals:before {
+      content: "";
+      display: block;
+      padding-top: 25%;
+    }
   }
 
   div.score > .content {
@@ -58,6 +66,12 @@ css:
     margin-top: -10px;
   }
 
+  div.xs-divider {
+    margin-top: -45px;
+  }
+
+<meta name="viewport" content="width=device-width" />
+
 section.container
   article.row#headline
     .col-lg-12.col-sm-12.col-xs-12
@@ -74,14 +88,22 @@ section.container
                 .row
                   .col-sm-offset-6.single
           .row
-            .col-sm-1.score.col-sm-offset-1 class=(step.css_class)
-              .content
-                h1 == step.score_text
-            .col-sm-9.details
+            - if step.title
+              .col-sm-1.score.col-sm-offset-1.score.col-xs-3.col-xs-offset-1 class=(step.css_class)
+                .content
+                  h1 == step.score_text
+            - else
+              .col-sm-1.score.col-sm-offset-1.score class=((step.css_class) + (' totals'))
+                .content
+                  h1 == step.score_text
+            .col-sm-9.details.col-xs-6.col-xs-offset-1.details
               - if step.title
                 h3.estimate-step-title == step.title
               - else
                 h3.estimate-step-title == "<br/>"
+              p.hidden-xs == step.description
+          .row.visible-xs.xs-divider
+            .col-xs-10.col-xs-offset-1
               p == step.description
         .row.divider
               .col-sm-1.col-sm-offset-1
@@ -89,8 +111,7 @@ section.container
                   .col-sm-offset-5.single
                   .col-sm-offset-7.single
         .row
-          .col-sm-1.score.col-sm-offset-1
+          .col-sm-1.score.col-sm-offset-1.totals
             .content
               h1 == @quality.total_score
-        
 


### PR DESCRIPTION
# Fix #151 
- Configured rows and cols according to design
- Added 1 `@media` query for the «top score»

This is how it currently looks on an `iPhone 6`:
![screen shot 2015-05-26 at 22 05 29](https://cloud.githubusercontent.com/assets/2642850/7828650/868b5f42-03f3-11e5-9c6e-1e1342195e65.png)
![screen shot 2015-05-26 at 22 05 43](https://cloud.githubusercontent.com/assets/2642850/7828651/868d511c-03f3-11e5-8ad8-7d5b8c1ae32e.png)

---
![Giphy](http://media2.giphy.com/media/iBrPXaAKbGyk/giphy.gif)