### PR TITLE
[Github pod Metrics] Switch to a left outer join to also render pod p…

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -135,7 +135,7 @@ class App < Sinatra::Base
   # joined pods/metrics query proxy.
   #
   def metrics
-    pods.join(:github_pod_metrics).on(:id => :pod_id).join(:cocoadocs_pod_metrics).on(:id => :pod_id)
+    pods.outer_join(:github_pod_metrics).on(:id => :pod_id).join(:cocoadocs_pod_metrics).on(:id => :pod_id)
   end
 
   # Setup assets.

--- a/views/pod.slim
+++ b/views/pod.slim
@@ -6,7 +6,7 @@ ruby:
   tested_description = @cocoadocs["total_test_expectations"] > 20 ? "Tested" : "Well Tested"
   has_docs = @cocoadocs["doc_percent"] > 20
   docs_description = @cocoadocs["doc_percent"] > 70 ? "Documented" : "Well Documented"
-  lang_small = @metrics["language"] == "Objective-C" ? "Obj-C" : @metrics["language"]
+  lang_small = @metrics["language"] == "Objective-C" ? "Obj-C" : @metrics["language"] if @metrics["language"]
 
 .pod_result
   div.pod-metadata.clearfix
@@ -23,6 +23,7 @@ ruby:
         tr
           td = tested_description
           td = has_tests ? "✓":"✗"
+      - if @metrics["language"]
         tr
           td Language
           td


### PR DESCRIPTION
…ages for pods without github metrics

From my testing it seems like there are few pods which have this issue.

```SQL
SELECT COUNT(*) FROM pods
INNER JOIN github_pod_metrics ON github_pod_metrics.pod_id = pods.id;
-- 10081 at the time of writing


SELECT COUNT(*) FROM pods;
-- 10082 at the time of writing
```

The only pod with this issue at the moment is `Manuscript` which is very new and probably haven't been indexed

cc @orta 
Issue: #152 