### PR TITLE
Frh owners page fix

### DIFF
--- a/views/owner.slim
+++ b/views/owner.slim
@@ -239,10 +239,6 @@ section.container
               th
                 h2 Community Impact
           tbody
-            / tr
-            /   td Average</br>quality
-            /   td class="quality_indicator quality_#{average_qi_group}"
-            /     == quality_indicator_svg
             tr
               td.result = impact[:apps].to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
               td apps touched

--- a/views/owner.slim
+++ b/views/owner.slim
@@ -33,7 +33,8 @@ ruby:
     end
   end
 
-  impact = @pods.reduce({}) do |sum, pod|
+  default = Hash.new(0)
+  impact = @pods.reduce(default) do |sum, pod|
     sum[:qi] = pod[:cocoadocs_pod_metric][:quality_estimate] + (sum[:qi] || 0)
     sum[:apps] = pod[:stat_metric][:app_total] + (sum[:apps] || 0)
     sum[:downloads] = pod[:stat_metric][:download_total] + (sum[:downloads] || 0)
@@ -41,10 +42,6 @@ ruby:
     sum[:loc] = pod[:cocoadocs_pod_metric][:total_lines_of_code] + (sum[:loc] || 0)
     sum
   end
-
-  average_qi = impact[:qi] / @pods.count
-  average_qi_group = quality_indicator_group average_qi
-
 
 css:
   #headline {


### PR DESCRIPTION
Owner pages of owners without pods crash. E.g. https://cocoapods.org/owners/2

This provides a fix that lets the page render.
However, it could be argued that an owner without pods should not be rendered, or rendered with completely different information. But I suggest we move onto that after this quick fix.