### PR TITLE
Fix quality indicator for quality of 100 exactly

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -36,7 +36,7 @@ class App < Sinatra::Base
     end
 
     def quality_indicator_group input
-      input > 100 ? "5" : (input / 20) + 1
+      input >= 100 ? "5" : (input / 20) + 1
     end
   end
 


### PR DESCRIPTION
Why:

When quality was exactly 100 the previous logic for
calculating the quality indicator group would incorrectly
result in 6 which results in the class `quality_6`.

Closes: #193