### PR TITLE
Remove verified QI from the not applied section

### DIFF
--- a/views/pod_quality.slim
+++ b/views/pod_quality.slim
@@ -141,7 +141,7 @@ section.container
           .col-sm-8.col-sm-offset-2
             h2 Metrics not applied
             ul
-              - @quality.unaffected_steps.each do |step|
+              - @quality.unaffected_steps.reject { |step| step.title == "Verified Owner" }.each do |step|
                 li
                   h4 == "#{step.title} <span class='#{step.css_class}'>#{step.score_text}</span>"
                   p == step.description


### PR DESCRIPTION
Think it's pretty annoying to see this in the vast majority of pods, so I'm hiding it for the not applied section.