### PR TITLE
Handle QIs not giving back a 404

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -143,7 +143,7 @@ class App < Sinatra::Base
     @quality, response_code = PodQualityEstimate.load_quality_estimate(@name)
     @page_title = "#{@name}'s Quality Estimate on CocoaPods.org"
 
-    if (400..404).include? response_code
+    if (400...600).cover? response_code
       not_found
     else
       slim :pod_quality

--- a/app.rb
+++ b/app.rb
@@ -143,7 +143,7 @@ class App < Sinatra::Base
     @quality, response_code = PodQualityEstimate.load_quality_estimate(@name)
     @page_title = "#{@name}'s Quality Estimate on CocoaPods.org"
 
-    if response_code == 404
+    if (400..404).include? response_code
       not_found
     else
       slim :pod_quality


### PR DESCRIPTION
We were getting a 400 ( probably ) from the QI server while it was being hammered, see #234 - so now we glob a range of 40X replies and give a 404.