### PR TITLE
Update installation instructions on homepage

### DIFF
--- a/views/index.slim
+++ b/views/index.slim
@@ -46,7 +46,7 @@
               gems. Further installation instructions are in [the guides](https://guides.cocoapods.org/using/getting-started.html#getting-started).
 
               <pre class="highlight">
-              $ sudo gem install cocoapods
+              $ sudo gem install cocoapods --pre
               </pre>
 
               We are currently building a Mac app that hosts CocoaPods, similar to how Xcode


### PR DESCRIPTION
The current production version of Cocoapods does not work with the current production versions of OS X and Xcode. Documenting that users are expected to install a prelease version will reduce spurious bug reports for issues that have been fixed for months – reference cocoapods/cocoapods#4345 for more information.