### PR TITLE
Fixes README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Ideally this website should be run through a sub-folder of [Strata](https://github.com/CocoaPods/Strata).
 
-1. Clone a copy of [Strata](https://github.com/CocoaPods/Strata) and run `rake clone`. Or if you just want this website `rake clone:cocoapods`.
+1. Clone a copy of [Strata](https://github.com/CocoaPods/Strata) and run `rake clone`. Or if you just want this website `rake clone["cocoapods.org"]`.
 2. Run `rake db:migrate` in Strata to update the database to the latest version.
 3. Add a `.env` file with in CocoaPods.org ENVIRONMENT variables, see `sample.env`.
 


### PR DESCRIPTION
Instructions list `clone:cocoapods` but there is no `cocoapods` subtask, it's an argument to Rake. Might have this wrong, please correct otherwise. 