### PR TITLE
Adds some interesting stats to the homepage

### DIFF
--- a/domain.rb
+++ b/domain.rb
@@ -38,4 +38,8 @@ DB = Flounder.domain connection do |dom|
   dom.entity :commits, :commit, 'commits'
   dom.entity :pod_versions, :pod_version, 'pod_versions'
   dom.entity :stats_metrics, :stat_metric, 'stats_metrics'
+
+  # General Stats
+  #
+  dom.entity :total_stats, :total_stat, 'total_stats'
 end

--- a/views/index.slim
+++ b/views/index.slim
@@ -1,3 +1,10 @@
+ruby:
+  total_libs = pods.size.round(-3)
+  total_apps = total_stats.order_by(:id.desc).first[:app_total].round(-5)
+  libraries = ActiveSupport::NumberHelper.number_to_human(total_libs, locale: "en-GB").downcase
+  apps = ActiveSupport::NumberHelper.number_to_human(total_apps, locale: "en-GB").downcase
+
+
 == partial "search-templates"
 == partial "search"
 
@@ -12,9 +19,7 @@
         h3.underlined What is CocoaPods
         <div class="header-horizontal-divider"><div class="index-arrow-down"></div><div class="index-enclosed-arrow-down"></div></div>
 
-        markdown:
-          CocoaPods is a dependency manager for Swift and Objective-C Cocoa projects. It has over eighteen thousand libraries and can help you scale your projects elegantly.
-          Interested in the news about Swift Package Manager? [Check our FAQ](https://guides.cocoapods.org/using/faq.html)
+        p == "CocoaPods is a dependency manager for Swift and Objective-C Cocoa projects. It has over #{libraries} libraries and used in #{apps} apps. CocoaPods can help you scale your projects elegantly."
 
 
     section.row


### PR DESCRIPTION
I also dropped the "about the Swift Package Manager" thing, SwiftPM is no surprise for anyone ATM, and more importantly we're linking to something that says "we'll see" not much to gain from that anymore.

Anyway, it adds some numbers - this is based on my local db, so they're off

![screen shot 2016-08-07 at 12 13 48 pm](https://cloud.githubusercontent.com/assets/49038/17463648/6fc0f7dc-5c98-11e6-8c10-546768083690.png)

It does mean that the front page now triggers 2 db calls, but one is limited to one item, and the other is a count of all rows - which I expect to be fast.