### PR TITLE
Take another stab at de-duplicating client side

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,7 @@ Bundler.require
 
 desc 'Start up the dynamic site'
 task :serve do
+  puts "Starting server at http://localhost:3000"
   sh "foreman start"
 end
 

--- a/assets/javascripts/search.config.js
+++ b/assets/javascripts/search.config.js
@@ -321,6 +321,19 @@ $(window).ready(function() {
     return true;
   };
 
+  // Removes all duplicates in an array according to their .id value
+  //
+  function removeDuplicatesByID(objectsArray) {
+      var ids = [], collection = [];
+      $.each(objectsArray, function (index, value) {
+          if ($.inArray(value.id, ids) == -1) {
+              ids.push(value.id);
+              collection.push(value);
+          }
+      });
+      return collection;
+  }
+
   pickyClient = new PickyClient({
     full: searchURL,
     fullResults: 20,
@@ -450,8 +463,10 @@ $(window).ready(function() {
       }
 
       // Render the JSON into HTML.
-      //
+      // Initially de-duping to avoid memory hiccups e.g. #231 #248
       var allocations = data.allocations;
+      allocations.allocations = removeDuplicatesByID(data.allocations.allocations);
+
       allocations.each(function(i, allocation) {
         allocation.entries = allocation.entries.map(function(i, entry) {
           return render(entry);
@@ -803,4 +818,5 @@ $(window).ready(function() {
   if (window.initial_query != "") {
     pickyClient.insertFromURL(window.initial_query);
   }
+
 });


### PR DESCRIPTION
I think my original implementation a while back was de-duping the `Picky::Allocations` JS object, which is like an array but contains a few useful functions. 

This now de-dupes the content of the picky allocations before sending them into the app's core to start creating the presentation layer.