### PR TITLE
recommend cocoapods stable version to support Xcode 7 and 8

### DIFF
--- a/views/index.slim
+++ b/views/index.slim
@@ -52,11 +52,7 @@ ruby:
 
               <pre class="highlight">
               # Xcode 7 + 8
-              $ sudo gem install cocoapods --pre
-
-              # Xcode 7
-              sudo gem install activesupport -v 4.2.6
-              sudo gem install cocoapods
+              $ sudo gem install cocoapods
               </pre>
 
               We also have a [Mac app](/app) for CocoaPods. It only gets major releases ATM though.


### PR DESCRIPTION
Now that Cocoapods 1.1.1 is out, there is no need to recommend the release candidate version of cocoapods to support Xcode 7 and 8