### PR TITLE
AppSight integration on a Pod page

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -65,17 +65,13 @@ $( document ).ready( function(){
 var rootSelector = ".space_for_appsight"
 
 var showAppSight = function(name) {
-  console.log("showing: " + name)
-
-  // if($(rootSelector + " button")) { }
   $.getJSON("https://www.appsight.io/api/1.0/sdks/find?filter=top-apps-using&cocoapod=" + name + "&callback=?", function( data ) {
-    console.log("Data")
     if (data.status && data.status.is_successful) {
       if (data.result) {
         $('<p>Apps using <a href="' + data.result.href + '">' + name + '</a></p>').appendTo(rootSelector)
 
         $.each(data.result.apps_using, function(i, app){
-          var a = $('<a href=' + app.href + '/>')
+          var a = $('<a href=' + app.href + ' targer="_blank"/>')
           $('<img/>', {
             src: app.icons[0].url,
             title: app.name,
@@ -87,21 +83,28 @@ var showAppSight = function(name) {
         })
 
         $(rootSelector + ' [data-toggle="tooltip"]').tooltip()
-        $('<sub>powered by <a href="http://appsight.io">AppSight.io</a></sub>').appendTo(rootSelector)
+        var settings = '<sub><a data-toggle="modal" data-target="#app_sight_info" href="#">Settings</a></sub>'
+        var poweredBy = '<sub>powered by <a href="http://appsight.io">AppSight.io</a></sub>'
+        $('<div style="display: flex; flex-direction: row; justify-content: space-between;">' + settings + poweredBy + '</div>').appendTo(rootSelector)
         $('<hr/>').appendTo(rootSelector)
       }
     }
   });
 }
 
+var disableAppSight = function(name) {
+  $.cookie('enable_appsight', 'nope')
+  $("#app_sight_info").modal('hide')
+  $(rootSelector).empty()
+  checkForAppSight(name)
+}
+
 var checkForAppSight = function(name) {
-  console.log("check " + name)
-  if(!$.cookie('enable_appsight')) {
-    $(rootSelector).append("<button class='btn' type='button'>Show Apps using " + name + "</button>").on('click', function (e) {
+  if($.cookie('enable_appsight') === "sure" ) {
+    $(rootSelector).append("<button class='btn' type='button'>Show Apps using " + name + "</button>").on('click', function (e) {  
       $.cookie('enable_appsight', "sure")
       showAppSight(name)
     })
-
   } else {
     showAppSight(name)
   }

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -65,6 +65,8 @@ $( document ).ready( function(){
 var rootSelector = ".space_for_appsight"
 
 var showAppSight = function(name) {
+  $(rootSelector).empty()
+  
   $.getJSON("https://www.appsight.io/api/1.0/sdks/find?filter=top-apps-using&cocoapod=" + name + "&callback=?", function( data ) {
     if (data.status && data.status.is_successful) {
       if (data.result) {
@@ -93,16 +95,17 @@ var showAppSight = function(name) {
 }
 
 var disableAppSight = function(name) {
-  $.cookie('enable_appsight', 'nope')
+  $.cookie('appsight', "false")
   $("#app_sight_info").modal('hide')
-  $(rootSelector).empty()
+  $(rootSelector).empty()  
   checkForAppSight(name)
 }
 
 var checkForAppSight = function(name) {
-  if($.cookie('enable_appsight') === "sure" ) {
-    $(rootSelector).append("<button class='btn' type='button'>Show Apps using " + name + "</button>").on('click', function (e) {  
-      $.cookie('enable_appsight', "sure")
+  if($.cookie('appsight') !== "enabled") {
+    $(rootSelector).append("<button class='btn' type='button'>Show Apps using " + name + "</button><hr/>")
+    $(rootSelector + " .btn").on('click', function (e) {  
+      $.cookie('appsight', "enabled")
       showAppSight(name)
     })
   } else {

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -28,7 +28,7 @@ var post_expansion_setup = function(){
         $(target).html(data);
       });
     }
-
+    
     $this.tab('show');
     return false;
   });
@@ -61,3 +61,48 @@ $( document ).ready( function(){
 
   post_expansion_setup();
 });
+
+var rootSelector = ".space_for_appsight"
+
+var showAppSight = function(name) {
+  console.log("showing: " + name)
+
+  // if($(rootSelector + " button")) { }
+  $.getJSON("https://www.appsight.io/api/1.0/sdks/find?filter=top-apps-using&cocoapod=" + name + "&callback=?", function( data ) {
+    console.log("Data")
+    if (data.status && data.status.is_successful) {
+      if (data.result) {
+        $('<p>Apps using <a href="' + data.result.href + '">' + name + '</a></p>').appendTo(rootSelector)
+
+        $.each(data.result.apps_using, function(i, app){
+          var a = $('<a href=' + app.href + '/>')
+          $('<img/>', {
+            src: app.icons[0].url,
+            title: app.name,
+            style: 'margin: 2px;',
+            "data-toggle": 'tooltip',
+            "data-placement": 'top'
+          }).appendTo(a)
+          $(a).appendTo(rootSelector)
+        })
+
+        $(rootSelector + ' [data-toggle="tooltip"]').tooltip()
+        $('<sub>powered by <a href="http://appsight.io">AppSight.io</a></sub>').appendTo(rootSelector)
+        $('<hr/>').appendTo(rootSelector)
+      }
+    }
+  });
+}
+
+var checkForAppSight = function(name) {
+  console.log("check " + name)
+  if(!$.cookie('enable_appsight')) {
+    $(rootSelector).append("<button class='btn' type='button'>Show Apps using " + name + "</button>").on('click', function (e) {
+      $.cookie('enable_appsight', "sure")
+      showAppSight(name)
+    })
+
+  } else {
+    showAppSight(name)
+  }
+}

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -28,7 +28,7 @@ var post_expansion_setup = function(){
         $(target).html(data);
       });
     }
-    
+
     $this.tab('show');
     return false;
   });
@@ -89,6 +89,9 @@ var showAppSight = function(name) {
         var poweredBy = '<sub>powered by <a href="http://appsight.io">AppSight.io</a></sub>'
         $('<div style="display: flex; flex-direction: row; justify-content: space-between;">' + settings + poweredBy + '</div>').appendTo(rootSelector)
         $('<hr/>').appendTo(rootSelector)
+      }
+      else {
+        $('<p style="font-size: 14px">Could not find ' +  name + ' on <a data-toggle="modal" data-target="#app_sight_info" href="#">AppSight.io</p><hr />').appendTo(rootSelector)
       }
     }
   });

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 *= require zero-clipboard.min.js
 *= require has_flash.js
 *= require ICanHaz.js
+*= require jquery.cookie.js
 */
 
 // Sets up tabs for README/CHANGELOGs

--- a/assets/javascripts/jquery.cookie.js
+++ b/assets/javascripts/jquery.cookie.js
@@ -1,0 +1,117 @@
+/*!
+ * jQuery Cookie Plugin v1.4.1
+ * https://github.com/carhartl/jquery-cookie
+ *
+ * Copyright 2013 Klaus Hartl
+ * Released under the MIT license
+ */
+(function (factory) {
+	if (typeof define === 'function' && define.amd) {
+		// AMD
+		define(['jquery'], factory);
+	} else if (typeof exports === 'object') {
+		// CommonJS
+		factory(require('jquery'));
+	} else {
+		// Browser globals
+		factory(jQuery);
+	}
+}(function ($) {
+
+	var pluses = /\+/g;
+
+	function encode(s) {
+		return config.raw ? s : encodeURIComponent(s);
+	}
+
+	function decode(s) {
+		return config.raw ? s : decodeURIComponent(s);
+	}
+
+	function stringifyCookieValue(value) {
+		return encode(config.json ? JSON.stringify(value) : String(value));
+	}
+
+	function parseCookieValue(s) {
+		if (s.indexOf('"') === 0) {
+			// This is a quoted cookie as according to RFC2068, unescape...
+			s = s.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+		}
+
+		try {
+			// Replace server-side written pluses with spaces.
+			// If we can't decode the cookie, ignore it, it's unusable.
+			// If we can't parse the cookie, ignore it, it's unusable.
+			s = decodeURIComponent(s.replace(pluses, ' '));
+			return config.json ? JSON.parse(s) : s;
+		} catch(e) {}
+	}
+
+	function read(s, converter) {
+		var value = config.raw ? s : parseCookieValue(s);
+		return $.isFunction(converter) ? converter(value) : value;
+	}
+
+	var config = $.cookie = function (key, value, options) {
+
+		// Write
+
+		if (value !== undefined && !$.isFunction(value)) {
+			options = $.extend({}, config.defaults, options);
+
+			if (typeof options.expires === 'number') {
+				var days = options.expires, t = options.expires = new Date();
+				t.setTime(+t + days * 864e+5);
+			}
+
+			return (document.cookie = [
+				encode(key), '=', stringifyCookieValue(value),
+				options.expires ? '; expires=' + options.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
+				options.path    ? '; path=' + options.path : '',
+				options.domain  ? '; domain=' + options.domain : '',
+				options.secure  ? '; secure' : ''
+			].join(''));
+		}
+
+		// Read
+
+		var result = key ? undefined : {};
+
+		// To prevent the for loop in the first place assign an empty array
+		// in case there are no cookies at all. Also prevents odd result when
+		// calling $.cookie().
+		var cookies = document.cookie ? document.cookie.split('; ') : [];
+
+		for (var i = 0, l = cookies.length; i < l; i++) {
+			var parts = cookies[i].split('=');
+			var name = decode(parts.shift());
+			var cookie = parts.join('=');
+
+			if (key && key === name) {
+				// If second argument (value) is a function it's a converter...
+				result = read(cookie, value);
+				break;
+			}
+
+			// Prevent storing a cookie that we couldn't decode.
+			if (!key && (cookie = read(cookie)) !== undefined) {
+				result[name] = cookie;
+			}
+		}
+
+		return result;
+	};
+
+	config.defaults = {};
+
+	$.removeCookie = function (key, options) {
+		if ($.cookie(key) === undefined) {
+			return false;
+		}
+
+		// Must not alter options, thus extending a fresh object...
+		$.cookie(key, '', $.extend({}, options, { expires: -1 }));
+		return !$.cookie(key);
+	};
+
+}));

--- a/assets/javascripts/search.config.js
+++ b/assets/javascripts/search.config.js
@@ -211,8 +211,8 @@ $(window).ready(function() {
       _gaq.push(['_trackPageview'], "/pods/" + result.data("pod-name"));
 
       /// This can be found in application.js
+      checkForAppSight(result.data("pod-name"))
       post_expansion_setup()
-      addCloseButton()
     }).fail(function() {
       result.removeClass("loading")
     });
@@ -224,7 +224,7 @@ $(window).ready(function() {
       if (target.is("li.result") == false) {
         target = $(event.target).parents("li.result")
       }
-      console.log(target)
+
       reduceSearchResult(target)
       event.stopPropagation()
       return false;

--- a/assets/javascripts/search.config.js
+++ b/assets/javascripts/search.config.js
@@ -213,6 +213,7 @@ $(window).ready(function() {
       /// This can be found in application.js
       checkForAppSight(result.data("pod-name"))
       post_expansion_setup()
+      addCloseButton()
     }).fail(function() {
       result.removeClass("loading")
     });

--- a/assets/stylesheets/pod.scss.erb
+++ b/assets/stylesheets/pod.scss.erb
@@ -578,8 +578,10 @@ li.twitter {
   > .btn, > div > .btn {
     color: #565656;
     background-color: $background-color;
-    margin:4px auto;
-    display:block;
+    margin: 4px auto;
+    display: block;
+    max-width: 100%;
+    white-space: normal;
   }
 
   .close-expanded a {

--- a/assets/stylesheets/pod.scss.erb
+++ b/assets/stylesheets/pod.scss.erb
@@ -575,7 +575,7 @@ li.twitter {
       padding-left: 8px;
     }
   }
-  > .btn {
+  > .btn, > div > .btn {
     color: #565656;
     background-color: $background-color;
     margin:4px auto;

--- a/views/pod.slim
+++ b/views/pod.slim
@@ -103,10 +103,11 @@ ruby:
 
       hr
 
-      == section("Code",
-        { "Files" => @cocoadocs["total_files"],
-          alt_spans("LOC", "Lines of Code") => @cocoadocs["total_lines_of_code"],
-        })
+      - unless is_binary
+        == section("Code",
+          { "Files" => @cocoadocs["total_files"],
+            alt_spans("LOC", "Lines of Code") => @cocoadocs["total_lines_of_code"],
+          })
 
     hr
 
@@ -146,22 +147,14 @@ ruby:
             button.close type="button" data-dismiss="modal" aria-label="Close"
               span aria-hidden="true" &times
 
-            h4.modal-title#appsight_label == "AppSight Integration"
+            h4.modal-title#appsight_label == "AppSight.io Integration"
 
           .modal-body
-            p == "You want to add <code>#{clipboard_text}</code> similar to the following to your Podfile:"
-            pre
-              code
-                - if is_for_testing
-                  == "target 'MyApp' do \n ...\nend\n\ntarget 'MyAppTests' do\n  #{clipboard_text}\nend"
-                - else
-                  == "target 'MyApp' do\n  #{clipboard_text}\nend"
-
-            p Then run a <code>pod install</code> inside your terminal, or from CocoaPods.app.
+            p The CocoaPods Website has an optional integration with <a href='http://appsight.io'>AppSight.io</a> that checks every pod you look at for apps which consume it.
+            p <a href='http://appsight.io'>AppSight.io</a> is a third-party service which tracks SDKs usage in the top iOS + Android apps.
+            p 
             hr
-            p Alternatively to give it a test run, run the command:
-            p == "<code>pod try #{@pod.name}</code>"
-
+            p You can turn it off by clicking here: <button type="button" class="btn btn-danger" onclick="disableAppSight('#{@pod.name}')">Disable</button>
 
 
     - if @pod.dependencies.count > 1

--- a/views/pod.slim
+++ b/views/pod.slim
@@ -108,8 +108,7 @@ ruby:
           { "Files" => @cocoadocs["total_files"],
             alt_spans("LOC", "Lines of Code") => @cocoadocs["total_lines_of_code"],
           })
-
-    hr
+        hr
 
     button.btn type="button" data-toggle="modal" data-target="#installation_guide" Installation Guide
 
@@ -178,10 +177,11 @@ ruby:
             td
       hr
 
-    - if @pod.screenshots.count < 0
+    - if @pod.screenshots.count > 0
       ul.screenshots
         - @pod.screenshots.each do |screenshot|
-          img src="#{screenshot}"
+          a href=screenshot 
+          img src=screenshot
       hr
 
     ul.links

--- a/views/pod.slim
+++ b/views/pod.slim
@@ -103,10 +103,6 @@ ruby:
 
       hr
 
-    - if is_binary
-      == section("Library", { alt_spans("Size", "Integration Size") => @cocoadocs["install_size"].to_s + " kb" })
-
-    - else
       == section("Code",
         { "Files" => @cocoadocs["total_files"],
           alt_spans("LOC", "Lines of Code") => @cocoadocs["total_lines_of_code"],
@@ -140,6 +136,71 @@ ruby:
             p == "<code>pod try #{@pod.name}</code>"
 
     hr
+
+    #space_for_appsight
+
+    javascript:
+      function showAppSight() {
+        $.getJSON("https://www.appsight.io/api/1.0/sdks/find?filter=top-apps-using&cocoapod=#{{@pod.name}}&callback=?", function( data ) {
+          console.log(data)
+          if (data.status && data.status.is_successful) {
+            if (data.result) {
+              $('<p>Apps using <a href="' +data.result.href + '">#{{@pod.name}}</a></p>').appendTo('#space_for_appsight')
+             
+              $.each(data.result.apps_using, function(i, app){
+                var a = $('<a href=' + app.href + '/>')
+                $('<img/>', {
+                  src: app.icons[0].url,
+                  title: app.name,
+                  style: 'margin: 2px;',
+                  "data-toggle": 'tooltip',
+                  "data-placement": 'top'
+                }).appendTo(a)
+                $(a).appendTo('#space_for_appsight')
+              })
+
+              $('#space_for_appsight [data-toggle="tooltip"]').tooltip()
+              $('<sub>powered by <a href="http://appsight.io">AppSight</a></sub>').appendTo('#space_for_appsight')
+              $('<hr/>').appendTo('#space_for_appsight')
+            }
+          }
+        });
+      }
+
+      if(!$.cookie('enable_appsight')) {
+        $("#space_for_appsight").append("<button class='btn' type='button'>Show Apps using #{@pod.name}</button>").on('click', function (e) {
+          $.cookie('enable_appsight', "sure")
+          showAppSight()
+        })
+
+      } else {
+        showAppSight()
+      }
+
+    .modal.fade#app_sight_info tabindex="-2" role="dialog" aria-labelledby="appsight_label" aria-hidden="true"
+      .modal-dialog
+        .modal-content
+          .modal-header
+            button.close type="button" data-dismiss="modal" aria-label="Close"
+              span aria-hidden="true" &times
+
+            h4.modal-title#appsight_label == "AppSight Integration"
+
+          .modal-body
+            p == "You want to add <code>#{clipboard_text}</code> similar to the following to your Podfile:"
+            pre
+              code
+                - if is_for_testing
+                  == "target 'MyApp' do \n ...\nend\n\ntarget 'MyAppTests' do\n  #{clipboard_text}\nend"
+                - else
+                  == "target 'MyApp' do\n  #{clipboard_text}\nend"
+
+            p Then run a <code>pod install</code> inside your terminal, or from CocoaPods.app.
+            hr
+            p Alternatively to give it a test run, run the command:
+            p == "<code>pod try #{@pod.name}</code>"
+
+
 
     - if @pod.dependencies.count > 1
       table

--- a/views/pod.slim
+++ b/views/pod.slim
@@ -181,7 +181,7 @@ ruby:
       ul.screenshots
         - @pod.screenshots.each do |screenshot|
           a href=screenshot 
-          img src=screenshot
+            img src=screenshot
       hr
 
     ul.links

--- a/views/pod.slim
+++ b/views/pod.slim
@@ -137,45 +137,7 @@ ruby:
 
     hr
 
-    #space_for_appsight
-
-    javascript:
-      function showAppSight() {
-        $.getJSON("https://www.appsight.io/api/1.0/sdks/find?filter=top-apps-using&cocoapod=#{{@pod.name}}&callback=?", function( data ) {
-          console.log(data)
-          if (data.status && data.status.is_successful) {
-            if (data.result) {
-              $('<p>Apps using <a href="' +data.result.href + '">#{{@pod.name}}</a></p>').appendTo('#space_for_appsight')
-             
-              $.each(data.result.apps_using, function(i, app){
-                var a = $('<a href=' + app.href + '/>')
-                $('<img/>', {
-                  src: app.icons[0].url,
-                  title: app.name,
-                  style: 'margin: 2px;',
-                  "data-toggle": 'tooltip',
-                  "data-placement": 'top'
-                }).appendTo(a)
-                $(a).appendTo('#space_for_appsight')
-              })
-
-              $('#space_for_appsight [data-toggle="tooltip"]').tooltip()
-              $('<sub>powered by <a href="http://appsight.io">AppSight</a></sub>').appendTo('#space_for_appsight')
-              $('<hr/>').appendTo('#space_for_appsight')
-            }
-          }
-        });
-      }
-
-      if(!$.cookie('enable_appsight')) {
-        $("#space_for_appsight").append("<button class='btn' type='button'>Show Apps using #{@pod.name}</button>").on('click', function (e) {
-          $.cookie('enable_appsight', "sure")
-          showAppSight()
-        })
-
-      } else {
-        showAppSight()
-      }
+    .space_for_appsight class="#{{@pod.name}}"
 
     .modal.fade#app_sight_info tabindex="-2" role="dialog" aria-labelledby="appsight_label" aria-hidden="true"
       .modal-dialog

--- a/views/pod_page.slim
+++ b/views/pod_page.slim
@@ -84,5 +84,9 @@ javascript:
       var current_url = window.location.toString().split('#')[0]
       history.replaceState(null, null, current_url + new_hash)
     })
-
   })
+
+    $(document).ready(function() {
+      checkForAppSight("#{{@pod.name}}")
+    })
+


### PR DESCRIPTION
So I've been chatting with [AppSight](http://appsight.io) for a year or two, and I'd got to a point where it felt like they in a good place and I think AppSight offers something really useful for our pod pages. So I've looked into adding support for AppSight in the sidebar in the least intrusive way possible.

It looks a bit like this:

![screen shot 2017-08-11 at 16 07 56](https://user-images.githubusercontent.com/49038/29230051-47d94a64-7eaf-11e7-883d-d940c13c996d.png)

Which tells you what app it is on hover, and links to their overview page

![screen shot 2017-08-11 at 16 08 40](https://user-images.githubusercontent.com/49038/29230087-65977418-7eaf-11e7-9bd2-e9e0fea7e535.png)

e.g. https://www.appsight.io/app/bitmoji

the link in the title gives  the appsight page for a lib:  https://www.appsight.io/sdk/bolts

---

This will an opt-in process. By default we check if a cookie has been set, and show a button to enable this. There'll be a way to turn it off too before I make this un-WIP.

