### PR TITLE
Update Xcode versions in instructions

### DIFF
--- a/views/index.slim
+++ b/views/index.slim
@@ -51,7 +51,7 @@ ruby:
               gems. Further installation instructions are in [the guides](https://guides.cocoapods.org/using/getting-started.html#getting-started).
 
               <pre class="highlight">
-              # Xcode 7 + 8
+              # Xcode 8 + 9
               $ sudo gem install cocoapods
               </pre>
 


### PR DESCRIPTION
# Why?

Because Xcode 7 is quite old and not many people use it.