### PR TITLE
Remove Google Analytics, and de-scale the usage of twitter scripts

### DIFF
--- a/assets/javascripts/search.config.js
+++ b/assets/javascripts/search.config.js
@@ -25,35 +25,30 @@ $(window).ready(function() {
   // Tracking the search results.
   //
   var trackAnalytics = function(data, query) {
-    var total = data.total;
-    if (total > 0) {
-      _gaq.push(['_trackEvent', 'search', 'with results', query, total]);
-    } else {
-      _gaq.push(['_trackEvent', 'search', 'not found', query, 0]);
-    }
+    // NOOP
   }
 
   // Tracking platform selection.
   //
   var trackPlatformSelection = function() {
-    _gaq.push(['_trackEvent', 'platform', 'switch platform', platformSelect.find('input:checked').val(), 1]);
+    // NOOP
   }
 
   // Tracking language
   var trackLanguageSelection = function() {
-    _gaq.push(['_trackEvent', 'language', 'switch language', languageSelect.find('input:checked').val(), 1]);
+    // NOOP
   }
 
   // Tracking category/categories selection.
   //
   var trackAllocationSelection = function(category, count) {
-    _gaq.push(['_trackEvent', 'allocation', 'filter categories', category, count]);
+    // NOOP
   }
 
   // Tracking category/categories selection.
   //
   var trackResultLinkSelection = function(href) {
-    _gaq.push(['_trackEvent', 'resultlink', 'click outbound link', href, 1]);
+    // NOOP
   }
 
   // Sets the checkbox labels correctly.
@@ -206,9 +201,6 @@ $(window).ready(function() {
       result.addClass("is-expanded")
       result.removeClass("loading")
       result.children(".expanded").children(".content")[0].innerHTML = html
-
-      // Track the page views for inline pods
-      _gaq.push(['_trackPageview'], "/pods/" + result.data("pod-name"));
 
       /// This can be found in application.js
       checkForAppSight(result.data("pod-name"))
@@ -693,7 +685,6 @@ $(window).ready(function() {
   //
   searchInput.on('input', function(e) {
     if ('' == this.value) {
-      _gaq.push(['_trackEvent', 'clear']);
       resetSearchInterface();
     } else {
       prepareSearchInterfaceForResults();

--- a/views/about.slim
+++ b/views/about.slim
@@ -243,3 +243,6 @@ section.title.container.about-section
               li
                 a href="https://github.com/#{contributor[:name]}"
                   img src="#{contributor[:avatar_url]}&size=96" width="48" height="48" title="#{contributor[:name]} - #{contributor[:commits]} #{commits} to core projects"
+
+javascript:
+  !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');

--- a/views/layout.slim
+++ b/views/layout.slim
@@ -17,6 +17,3 @@ html lang="en-en"
 
     .clearfix
     == shared_partial("footer")
-
-javascript:
-  !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');

--- a/views/layout.slim
+++ b/views/layout.slim
@@ -20,12 +20,3 @@ html lang="en-en"
 
 javascript:
   !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');
-
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-29866548-1']);
-  _gaq.push(['_trackPageview']);
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();


### PR DESCRIPTION
We originally added GA when building out CP.org to get a sense of what to focus our attention to when transitioning to the new site, to understand the scope of features used in search and as a potential stat for a Pod for quality metrics - I basically wanted to pass back the numbers to the pod pages about its traffic.

It turned out getting your own data was harder than I expected. So I never succeeded in pulling that off. Shame. 

But all of these cases aren't useful anymore now it's mature, so why are we tracking people on the website? Mainly because we haven't turned it off. Which this now does.