### PR TITLE
remove documentation button when not specified in podspec

### DIFF
--- a/spec_extensions.rb
+++ b/spec_extensions.rb
@@ -30,7 +30,7 @@ module Pod
     end
 
     def or_web_documentation_url
-      documentation_url || or_cocoadocs_url
+      documentation_url || ""
     end
 
     def or_cocoapods_url

--- a/spec_extensions.rb
+++ b/spec_extensions.rb
@@ -30,7 +30,7 @@ module Pod
     end
 
     def or_web_documentation_url
-      documentation_url || ""
+      documentation_url || or_cocoadocs_url
     end
 
     def or_cocoapods_url

--- a/views/pod.slim
+++ b/views/pod.slim
@@ -193,7 +193,7 @@ ruby:
     ul.links
       li
         a href=@pod.or_podspec_url See Podspec
-      - if @pod.or_web_documentation_url != ""
+      - if @pod.or_web_documentation_url
         li
           a href=@pod.or_web_documentation_url Documentation
 

--- a/views/pod.slim
+++ b/views/pod.slim
@@ -193,8 +193,9 @@ ruby:
     ul.links
       li
         a href=@pod.or_podspec_url See Podspec
-      li
-        a href=@pod.or_web_documentation_url Documentation
+      - if @pod.or_web_documentation_url != ""
+        li
+          a href=@pod.or_web_documentation_url Documentation
 
       - if @pod.or_github_url
         li

--- a/views/pod.slim
+++ b/views/pod.slim
@@ -193,9 +193,9 @@ ruby:
     ul.links
       li
         a href=@pod.or_podspec_url See Podspec
-      - if @pod.or_web_documentation_url
+      - if @pod.documentation_url
         li
-          a href=@pod.or_web_documentation_url Documentation
+          a href=@pod.documentation_url Documentation
 
       - if @pod.or_github_url
         li


### PR DESCRIPTION
The cocoadocs has been broken for a while now. This will remove the documentation button when the podspec doesn't specify a documentation url. Fixes issue #380