### PR TITLE
Remove the quality link

### DIFF
--- a/views/pod.slim
+++ b/views/pod.slim
@@ -231,10 +231,6 @@ ruby:
             a.hidden-xs href=@pod.or_github_url ="#{@pod.or_user}/#{@pod.or_repo}"
             a.visible-xs href=@pod.or_github_url GitHub Repo
 
-        - if has_full_metadata
-          a href="/pods/#{@pod.name}/quality"
-            li class="metadata quality_indicator quality_#{quality_group}"
-              == quality_indicator_svg
     .clearfix
 
     - if is_deprecated


### PR DESCRIPTION
It's been a year or so since CocoaDocs was turned off, and so a lot of the quality scores aren't up to date (and also not really used in the new search alogorithm ) 

So, it's better to just not have it anymore. 