### PR TITLE
Show CHANGELOG tab when possible.

### DIFF
--- a/views/pod.slim
+++ b/views/pod.slim
@@ -23,7 +23,7 @@ ruby:
   is_for_testing = has_full_metadata && @pod.attributes_hash["frameworks"] && @pod.attributes_hash["frameworks"].include?("XCTest")
   quality_group = has_full_metadata && quality_indicator_group(@cocoadocs["quality_estimate"])
   is_binary = has_full_metadata && @cocoadocs["is_vendored_framework"]
-  has_changelog = has_full_metadata && @cocoadocs["rendered_changelog_url"]
+  has_changelog = @cocoadocs["rendered_changelog_url"]
   is_swift = has_full_metadata && @cocoadocs["dominant_language"] == "Swift"
 
   def section(title, table_class="inset", include_zero=true, properties)


### PR DESCRIPTION
The ARCore pod page (https://cocoapods.org/pods/ARCore) currently doesn't show the CHANGELOG tab, even though the data is actually there (https://cocoapods.org/pods/ARCore/changelog). The tab switcher should show whenever possible (when there is a CHANGELOG). (Note: the README and CHANGELOG rendering incorrectly in this example are a separate problem fixed here: https://github.com/CocoaPods/cocoapods-metadata-service/pull/20).