### PR TITLE
Add link to podspec in search results

### DIFF
--- a/assets/javascripts/search.config.js
+++ b/assets/javascripts/search.config.js
@@ -259,6 +259,8 @@ $(window).ready(function() {
 
     entry.link = "https://cocoapods.org/pods/" + entry.name 
     entry.site_link = entry.homepage || extractRepoFromSource(entry)
+    const md5fragment = md5(entry.name).split('').slice(0,3).join('/')
+    entry.podspec = `https://github.com/CocoaPods/Specs/blob/master/Specs/${md5fragment}/${entry.name}/${entry.version}/${entry.name}.podspec.json`
 
     // If the version string has any non-numeric characters (pre-release or build metadata flags),
     // the clipboard copy prompt should use the raw version number.

--- a/views/partials/_search-templates.slim
+++ b/views/partials/_search-templates.slim
@@ -33,6 +33,7 @@ script id="search_result" type="text/html"
 
     .actions.col-sm-4.col-xs-12
       div.action-wrapper
+        a href="{{ podspec }}" Podspec
         a href="{{ site_link }}" Site
 
 script id="expandable_search_result" type="text/html"
@@ -67,4 +68,5 @@ script id="expandable_search_result" type="text/html"
 
     .actions.col-sm-3.col-xs-12
      div.action-wrapper
+      a href="{{ podspec }}" Podspec
       a href="#" Expand

--- a/views/partials/_search.slim
+++ b/views/partials/_search.slim
@@ -1,4 +1,5 @@
 script src="https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js"
+script src="https://cdn.jsdelivr.net/npm/pure-md5@0.1.13"
 
 #search_container.container
   section.row


### PR DESCRIPTION
When searching for a pod that doesn't have a `/pods/:name` landing page, e.g. `GoogleMobileAdsMediationVerizonMedia`, I get redirected to an external website. 

This prevents me from being able to open the podspec for the pods.

This PR adds an action link to the podspec next to the "Site" link.