### PR TITLE
Fix "See Podspecs" URL on Cocoapods.org website

### DIFF
--- a/spec_extensions.rb
+++ b/spec_extensions.rb
@@ -25,8 +25,15 @@ module Pod
     end
 
     def or_podspec_url
-      "https://github.com/CocoaPods/Specs/blob/master/Specs/" \
-        "#{MasterRepoMetadata.path_fragment(name, version)}/#{ name }.podspec.json"
+      path_fragment = MasterRepoMetadata.path_fragment(name, version)
+    
+      decoded_fragment = URI.decode(path_fragment)
+      parsed_fragment = decoded_fragment.scan(/\"(.*?)\"/).flatten
+    
+      char1, char2, char3, pod_name, version_number = parsed_fragment
+      version_number = version_number.match(/(\d+\.\d+\.\d+)/)[1]
+    
+      return "https://github.com/CocoaPods/Specs/blob/master/Specs/#{char1}/#{char2}/#{char3}/#{pod_name}/#{version_number}/#{pod_name}.podspec.json"
     end
 
     def or_web_documentation_url


### PR DESCRIPTION
See Podspecs link on the website are broken. 

Example: 

https://github.com/CocoaPods/Specs/blob/master/Specs/[%229%22,%20%22c%22,%20%22c%22,%20%22AppLovinSDK%22,%20%3CPod::Version%20version=12.1.0%3E]/AppLovinSDK.podspec.json


Should be

https://github.com/CocoaPods/Specs/blob/master/Specs/9/c/c/AppLovinSDK/12.1.0/AppLovinSDK.podspec.json


https://github.com/CocoaPods/cocoapods.org/assets/3648336/4f8106f7-bcf5-475e-a634-5aeb40e49394



This PR updates the `or_podspec_url` logic to fix this. 

